### PR TITLE
Fixed guitar pictures not loading on return from setups view

### DIFF
--- a/ngGuitarTech/.vscode/settings.json
+++ b/ngGuitarTech/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "workbench.editor.enablePreview": false
+}

--- a/ngGuitarTech/src/app/components/guitars/guitars.component.ts
+++ b/ngGuitarTech/src/app/components/guitars/guitars.component.ts
@@ -67,6 +67,8 @@ export class GuitarsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
 		// this.toastServ.clear();
+    console.log('leaving guitars');
+    localStorage.setItem('guitars', JSON.stringify(this.guitars));
 	}
 
   loadUserGuitarPictures() {
@@ -94,5 +96,13 @@ export class GuitarsComponent implements OnInit, OnDestroy {
     return this.router.url.includes(route);
   }
 
-  get guitars() { return this.guitarServ.guitarsList; }
+  get guitars() {
+    const guitarsString = localStorage.getItem('guitars');
+
+    if (guitarsString !== null) {
+      this.guitarServ.loadGuitars(JSON.parse(guitarsString));
+      localStorage.removeItem('guitars');
+    }
+
+    return this.guitarServ.guitarsList; }
 }


### PR DESCRIPTION
A little hacky but it uses localStorage to store the guitarsList since the guitars component and all its instance properties die when you navigate to setups. In the future I would like to control this via an app-service that stays alive the whole time.